### PR TITLE
remove clearMemory, upgrade coroutines

### DIFF
--- a/app/src/test/java/com/nytimes/android/sample/KeyParserTest.kt
+++ b/app/src/test/java/com/nytimes/android/sample/KeyParserTest.kt
@@ -4,7 +4,8 @@ import com.nytimes.android.external.store3.base.Fetcher
 import com.nytimes.android.external.store3.base.Parser
 import com.nytimes.android.external.store3.base.impl.Store
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -13,31 +14,31 @@ import org.mockito.runners.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
 class KeyParserTest {
-  lateinit var store: Store<String, Int>
+    lateinit var store: Store<String, Int>
+    private val testScope = TestCoroutineScope()
 
-  @Before
-  @Throws(Exception::class)
-  fun setUp() {
-    store = StoreBuilder.parsedWithKey<Int, String, String>()
-        .parser(object : Parser<String, String> {
-          override suspend fun apply(raw: String): String = raw + KEY
-        })
-        .fetcher(object : Fetcher<String, Int> {
-          override suspend fun fetch(key: Int): String = NETWORK
-        })
-        .open()
-  }
-
-  @Test
-  fun testStoreWithKeyParserFuncNoPersister() {
-    runBlocking {
-      assertThat(store.get(KEY)).isEqualTo(NETWORK + KEY)
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        store = StoreBuilder.parsedWithKey<Int, String, String>()
+                .parser(object : Parser<String, String> {
+                    override suspend fun apply(raw: String): String = raw + KEY
+                })
+                .fetcher(object : Fetcher<String, Int> {
+                    override suspend fun fetch(key: Int): String = NETWORK
+                })
+                .open()
     }
-  }
 
-  companion object {
+    @Test
+    fun testStoreWithKeyParserFuncNoPersister() = testScope.runBlockingTest {
+        assertThat(store.get(KEY)).isEqualTo(NETWORK + KEY)
+    }
 
-    val NETWORK = "Network"
-    val KEY = 5
-  }
+
+    companion object {
+
+        val NETWORK = "Network"
+        val KEY = 5
+    }
 }

--- a/app/src/test/java/com/nytimes/android/sample/NoNetworkTest.kt
+++ b/app/src/test/java/com/nytimes/android/sample/NoNetworkTest.kt
@@ -3,15 +3,18 @@ package com.nytimes.android.sample
 import com.nytimes.android.external.store3.base.impl.BarCode
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
 class NoNetworkTest {
     private val store = StoreBuilder.barcode<Any>()
             .fetcher { throw EXCEPTION }
             .open()
+    private val testScope = TestCoroutineScope()
 
     @Test(expected = java.lang.Exception::class)
-    fun testNoNetwork() = runBlocking<Unit> {
+    fun testNoNetwork() = testScope.runBlockingTest {
         store.get(BarCode("test", "test"))
     }
 

--- a/app/src/test/java/com/nytimes/android/sample/StoreIntegrationTest.kt
+++ b/app/src/test/java/com/nytimes/android/sample/StoreIntegrationTest.kt
@@ -5,6 +5,8 @@ import com.nytimes.android.external.store3.base.impl.Store
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -15,11 +17,12 @@ class StoreIntegrationTest {
     private val store: Store<String, BarCode> = StoreBuilder.barcode<String>()
             .fetcher { atomicInt.incrementAndGet().toString() }
             .open()
+    private val testScope = TestCoroutineScope()
 
     @Test
     fun testRepeatedGet() {
         val barcode = BarCode.empty()
-        runBlocking {
+        testScope.runBlockingTest {
             val first = store.fresh(barcode)
             val same = store.get(barcode)
             assertEquals(first, same)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply from: 'buildsystem/dependencies.gradle'
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.3.41'
     repositories {
         mavenCentral()
         maven {
@@ -19,7 +19,7 @@ buildscript {
     }
 
     rootProject.ext.versions = [
-        kotlin: '1.3.21'
+        kotlin: '1.3.41'
     ]
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-beta05'
+        classpath 'com.android.tools.build:gradle:3.6.0-alpha05'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.5.6'
 //        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11'

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -14,7 +14,7 @@ ext.versions = [
         targetSdk            : 28,
         compileSdk           : 28,
         buildTools           : '28.0.3',
-        kotlin               : '1.3.40',
+        kotlin               : '1.3.41',
 
         // UI libs.
         supportLibs          : '28.0.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 17 16:50:26 EDT 2019
+#Sat Aug 03 18:45:43 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip

--- a/middleware/src/test/java/com/nytimes/android/external/store3/GenericParserStoreTest.kt
+++ b/middleware/src/test/java/com/nytimes/android/external/store3/GenericParserStoreTest.kt
@@ -9,7 +9,6 @@ import com.nytimes.android.external.store3.base.Persister
 import com.nytimes.android.external.store3.base.impl.BarCode
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
 import com.nytimes.android.external.store3.middleware.GsonParserFactory
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import okio.BufferedSource

--- a/middleware/src/test/java/com/nytimes/android/external/store3/GenericParserStoreTest.kt
+++ b/middleware/src/test/java/com/nytimes/android/external/store3/GenericParserStoreTest.kt
@@ -10,6 +10,8 @@ import com.nytimes.android.external.store3.base.impl.BarCode
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
 import com.nytimes.android.external.store3.middleware.GsonParserFactory
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import okio.BufferedSource
 import okio.Okio
 import org.assertj.core.api.Assertions.assertThat
@@ -22,9 +24,10 @@ class GenericParserStoreTest {
     private val fetcher: Fetcher<BufferedSource, BarCode> = mock()
     private val persister: Persister<BufferedSource, BarCode> = mock()
     private val barCode = BarCode("value", KEY)
+    private val testScope = TestCoroutineScope()
 
     @Test
-    fun testSimple() = runBlocking<Unit> {
+    fun testSimple() = testScope.runBlockingTest {
         val parser = GsonParserFactory.createSourceParser<Foo>(Gson())
 
         val simpleStore = StoreBuilder.parsedWithKey<BarCode, BufferedSource, Foo>()

--- a/middleware/src/test/java/com/nytimes/android/external/store3/GsonSourceListParserTest.kt
+++ b/middleware/src/test/java/com/nytimes/android/external/store3/GsonSourceListParserTest.kt
@@ -10,6 +10,8 @@ import com.nytimes.android.external.store3.base.impl.BarCode
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
 import com.nytimes.android.external.store3.middleware.GsonParserFactory
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import okio.BufferedSource
 import okio.Okio
 import org.assertj.core.api.Assertions.assertThat
@@ -23,9 +25,10 @@ class GsonSourceListParserTest {
     private val fetcher: Fetcher<BufferedSource, BarCode> = mock()
     private val persister: Persister<BufferedSource, BarCode> = mock()
     private val barCode = BarCode("value", KEY)
+    private val testScope = TestCoroutineScope()
 
     @Test
-    fun testSimple() = runBlocking<Unit> {
+    fun testSimple() = runBlockingTest {
         val parser = GsonParserFactory.createSourceParser<List<Foo>>(Gson())
 
 

--- a/store/gradle.properties
+++ b/store/gradle.properties
@@ -2,4 +2,3 @@ POM_NAME=com.nytimes.android
 POM_ARTIFACT_ID=store3
 POM_PACKAGING=aar
 android.enableAapt2=false
-kotlin.coroutines=enable

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.kt
@@ -53,11 +53,6 @@ interface Store<T, V> {
             stream().filter { it.first == key }.map { (_, value) -> value }
 
     /**
-     * Clear the memory cache of all entries
-     */
-    suspend fun clearMemory()
-
-    /**
      * Purge a particular entry from memory and disk cache.
      * Persister will only be cleared if they implements Clearable
      */

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Cache.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Cache.kt
@@ -30,11 +30,6 @@ internal class MemoryCacheStore<V, K>(
     @FlowPreview
     override fun stream(): Flow<Pair<K, V>> = wrappedStore.stream()
 
-    override suspend fun clearMemory() {
-        memCache.clearAll()
-        wrappedStore.clearMemory()
-    }
-
     override suspend fun clear(key: K) {
         memCache.invalidate(key)
         wrappedStore.clear(key)

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/FetcherStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/FetcherStore.kt
@@ -34,9 +34,6 @@ internal class FetcherStore<Raw, Key>(
                     .drop(1)
                     .map { it!! }
 
-    override suspend fun clearMemory() {
-    }
-
     override suspend fun clear(key: Key) {
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Inflight.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Inflight.kt
@@ -37,11 +37,6 @@ internal class InflightStore<V, K>(
     @FlowPreview
     override fun stream(): Flow<Pair<K, V>> = wrappedStore.stream()
 
-    override suspend fun clearMemory() {
-        inFlightRequests.clearAll()
-        wrappedStore.clearMemory()
-    }
-
     override suspend fun clear(key: K) {
         inFlightRequests.invalidate(key)
         wrappedStore.clear(key)

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Parser.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Parser.kt
@@ -30,10 +30,6 @@ internal class ParserStore<V1, V2, K>(
     @FlowPreview
     override fun stream(): Flow<Pair<K, V2>> = wrappedStore.stream().map { (key, value) -> key to parser.apply(key, value) }
 
-    override suspend fun clearMemory() {
-        wrappedStore.clearMemory()
-    }
-
     override suspend fun clear(key: K) {
         wrappedStore.clear(key)
     }

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Persister.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Persister.kt
@@ -59,10 +59,7 @@ internal class PersisterStore<V, K>(
 
 
     override suspend fun clear(key: K) {
-        // TODO we should somehow receive it or not make this suspend
-       withContext(Dispatchers.IO) {
-            StoreUtil.clearPersister<Any, K>(persister, key)
-        }
+        StoreUtil.clearPersister<Any, K>(persister, key)
         wrappedStore.clear(key)
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Persister.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Persister.kt
@@ -57,14 +57,12 @@ internal class PersisterStore<V, K>(
     @FlowPreview
     override fun stream(): Flow<Pair<K, V>> = wrappedStore.stream()
 
-    override suspend fun clearMemory() {
-        wrappedStore.clearMemory()
-    }
 
     override suspend fun clear(key: K) {
         // TODO we should somehow receive it or not make this suspend
-        withContext(Dispatchers.IO) {
+        CoroutineScope(Dispatchers.IO).launch {
             StoreUtil.clearPersister<Any, K>(persister, key)
         }
+        wrappedStore.clear(key)
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Persister.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/wrappers/Persister.kt
@@ -60,7 +60,7 @@ internal class PersisterStore<V, K>(
 
     override suspend fun clear(key: K) {
         // TODO we should somehow receive it or not make this suspend
-        CoroutineScope(Dispatchers.IO).launch {
+       withContext(Dispatchers.IO) {
             StoreUtil.clearPersister<Any, K>(persister, key)
         }
         wrappedStore.clear(key)

--- a/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineCacheStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineCacheStore.kt
@@ -40,11 +40,6 @@ internal class PipelineCacheStore<Key, Output>(
         }
     }
 
-    override suspend fun clearMemory() {
-        memCache.clearAll()
-        delegate.clearMemory()
-    }
-
     override suspend fun clear(key: Key) {
         memCache.invalidate(key)
         delegate.clear(key)

--- a/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineConverterStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineConverterStore.kt
@@ -23,11 +23,7 @@ class PipelineConverterStore<Key, OldOutput, NewOutput>(
         }
     }
 
-    override suspend fun clearMemory() {
-        delegate.clearMemory()
-    }
-
     override suspend fun clear(key: Key) {
-        delegate.clearMemory()
+        delegate.clear(key)
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineFetcherStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineFetcherStore.kt
@@ -9,9 +9,7 @@ internal class PipelineFetcherStore<Key, Output>(
 ) : PipelineStore<Key, Output> {
     override fun stream(request: StoreRequest<Key>) = fetcher(request.key)
 
-    override suspend fun clearMemory() {
 
-    }
 
     override suspend fun clear(key: Key) {
     }

--- a/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelinePersister.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelinePersister.kt
@@ -53,9 +53,6 @@ class PipelinePersister<Key, Input, Output>(
         }
     }
 
-    override suspend fun clearMemory() {
-        fetcher.clearMemory()
-    }
 
     override suspend fun clear(key: Key) {
         fetcher.clear(key)

--- a/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/pipeline/PipelineStore.kt
@@ -21,11 +21,6 @@ interface PipelineStore<Key, Output> {
     fun stream(request: StoreRequest<Key>): Flow<Output>
 
     /**
-     * Clear the memory cache of all entries
-     */
-    suspend fun clearMemory()
-
-    /**
      * Purge a particular entry from memory and disk cache.
      * Persister will only be cleared if they implements Clearable
      */
@@ -38,11 +33,11 @@ fun <Key, Output> PipelineStore<Key, Output>.open(): Store<Output, Key> {
     return object : Store<Output, Key> {
         override suspend fun get(key: Key) = self.stream(
                 StoreRequest.cached(key, refresh = false)
-        ).take(1).toList().first()
+        ).first()
 
         override suspend fun fresh(key: Key) = self.stream(
                 StoreRequest.fresh(key)
-        ).take(1).toList().first()
+        ).first()
 
         // We could technically implement this based on other calls but it does have a cost,
         // implementation is tricky and yigit is not sure what the use case is ¯\_(ツ)_/¯
@@ -63,9 +58,7 @@ fun <Key, Output> PipelineStore<Key, Output>.open(): Store<Output, Key> {
                 }
         }
 
-        override suspend fun clearMemory() {
-            self.clearMemory()
-        }
+
 
         override suspend fun clear(key: Key) = self.clear(key)
 

--- a/store/src/test/java/com/nytimes/android/external/store3/ClearStoreTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/ClearStoreTest.kt
@@ -5,6 +5,8 @@ import com.nhaarman.mockitokotlin2.whenever
 import com.nytimes.android.external.store3.base.impl.BarCode
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,6 +19,8 @@ import java.util.concurrent.atomic.AtomicInteger
 class ClearStoreTest(
         storeType: TestStoreType
 ) {
+    private val testScope = TestCoroutineScope()
+
     private val persister: ClearingPersister = mock()
     private val networkCalls = AtomicInteger(0)
 
@@ -28,7 +32,7 @@ class ClearStoreTest(
     ).build(storeType)
 
     @Test
-    fun testClearSingleBarCode() = runBlocking<Unit> {
+    fun testClearSingleBarCode() = testScope.runBlockingTest {
         // one request should produce one call
         val barcode = BarCode("type", "key")
 
@@ -51,7 +55,7 @@ class ClearStoreTest(
     }
 
     @Test
-    fun testClearAllBarCodes() = runBlocking<Unit> {
+    fun testClearAllBarCodes() = testScope.runBlockingTest {
         val barcode1 = BarCode("type1", "key1")
         val barcode2 = BarCode("type2", "key2")
 

--- a/store/src/test/java/com/nytimes/android/external/store3/ClearStoreTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/ClearStoreTest.kt
@@ -77,8 +77,8 @@ class ClearStoreTest(
         store.get(barcode2)
         assertThat(networkCalls.toInt()).isEqualTo(2)
 
-        store.clearMemory()
-
+        store.clear(barcode1)
+        store.clear(barcode2)
         // after everything is cleared each request should produce another 2 calls
         store.get(barcode1)
         store.get(barcode2)

--- a/store/src/test/java/com/nytimes/android/external/store3/KeyParserTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/KeyParserTest.kt
@@ -3,6 +3,8 @@ package com.nytimes.android.external.store3
 import com.nytimes.android.external.store3.util.KeyParser
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +15,8 @@ import org.junit.runners.Parameterized
 class KeyParserTest(
         storeType: TestStoreType
 ) {
+    private val testScope = TestCoroutineScope()
+
     private val store = TestStoreBuilder.from(
             fetcher = {
                 NETWORK
@@ -25,7 +29,7 @@ class KeyParserTest(
     ).build(storeType)
 
     @Test
-    fun testStoreWithKeyParserFuncNoPersister() = runBlocking<Unit> {
+    fun testStoreWithKeyParserFuncNoPersister() = testScope.runBlockingTest {
         assertThat(store.get(KEY)).isEqualTo(NETWORK + KEY)
     }
 

--- a/store/src/test/java/com/nytimes/android/external/store3/NoNetworkTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/NoNetworkTest.kt
@@ -4,6 +4,8 @@ import com.nytimes.android.external.store3.base.impl.BarCode
 import com.nytimes.android.external.store3.base.impl.Store
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
@@ -18,9 +20,10 @@ class NoNetworkTest(
     private val store: Store<out Any, BarCode> = TestStoreBuilder.from<BarCode, Any> {
         throw EXCEPTION
     }.build(storeType)
+    private val testScope = TestCoroutineScope()
 
     @Test
-    fun testNoNetwork() = runBlocking<Unit> {
+    fun testNoNetwork() = testScope.runBlockingTest {
         try {
             store.get(BarCode("test", "test"))
             fail("Exception not thrown")

--- a/store/src/test/java/com/nytimes/android/external/store3/SequentialTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/SequentialTest.kt
@@ -9,6 +9,8 @@ import com.nytimes.android.external.store3.base.wrappers.persister
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,6 +21,7 @@ import kotlin.random.Random
 @RunWith(Parameterized::class)
 class SequentialTes(
         storeType: TestStoreType) {
+    private val testScope = TestCoroutineScope()
 
     var networkCalls = 0
     private val store = TestStoreBuilder.from<BarCode, Int>(cached = true) {
@@ -26,7 +29,7 @@ class SequentialTes(
     }.build(storeType)
 
     @Test
-    fun sequentially() = runBlocking<Unit> {
+    fun sequentially() = testScope.runBlockingTest {
         val b = BarCode("one", "two")
         store.get(b)
         store.get(b)
@@ -35,7 +38,7 @@ class SequentialTes(
     }
 
     @Test
-    fun parallel() = runBlocking<Unit> {
+    fun parallel() = testScope.runBlockingTest {
         val b = BarCode("one", "two")
         val deferred = async { store.get(b) }
         store.get(b)
@@ -45,7 +48,7 @@ class SequentialTes(
     }
 
     @Test
-    fun cacheWithParser() = runBlocking<Unit> {
+    fun cacheWithParser() = testScope.runBlockingTest {
         val persister: Persister<String, Int> = object : Persister<String, Int> {
             private val map = mutableMapOf<Int, String>()
             override suspend fun read(key: Int): String? = map[key]

--- a/store/src/test/java/com/nytimes/android/external/store3/StoreBuilderTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/StoreBuilderTest.kt
@@ -7,14 +7,17 @@ import com.nytimes.android.external.store3.base.impl.Store
 import com.nytimes.android.external.store3.base.wrappers.parser
 import com.nytimes.android.external.store3.base.wrappers.persister
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.util.*
 
 class StoreBuilderTest {
+    private val testScope = TestCoroutineScope()
 
     @Test
-    fun testBuildersBuildWithCorrectTypes() = runBlocking<Unit> {
+    fun testBuildersBuildWithCorrectTypes() = testScope.runBlockingTest {
         //test  is checking whether types are correct in builders
         val store: Store<Date, Int> = Store.from<String, Int> { key ->
             key.toString()

--- a/store/src/test/java/com/nytimes/android/external/store3/StoreTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/StoreTest.kt
@@ -95,7 +95,7 @@ class StoreTest(
                 persister = persister
         ).build(storeType)
 
-        simpleStore.clearMemory()
+        simpleStore.clear(barCode)
 
         whenever(fetcher.fetch(barCode))
                 .thenReturn(NETWORK)
@@ -105,7 +105,7 @@ class StoreTest(
                 .thenReturn(DISK)
         whenever(persister.write(barCode, NETWORK)).thenReturn(true)
 
-        var value = simpleStore.get(barCode)
+            var value = simpleStore.get(barCode)
         assertThat(value).isEqualTo(DISK)
         value = simpleStore.get(barCode)
         assertThat(value).isEqualTo(DISK)

--- a/store/src/test/java/com/nytimes/android/external/store3/StoreThrowOnNoItems.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/StoreThrowOnNoItems.kt
@@ -1,15 +1,12 @@
 package com.nytimes.android.external.store3
 
-import com.nhaarman.mockitokotlin2.*
-import com.nytimes.android.external.cache3.CacheBuilder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import com.nytimes.android.external.store3.base.Fetcher
 import com.nytimes.android.external.store3.base.Persister
 import com.nytimes.android.external.store3.base.impl.BarCode
-import com.nytimes.android.external.store3.base.impl.StalePolicy
-import com.nytimes.android.external.store3.util.NoopPersister
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
@@ -17,7 +14,6 @@ import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 @ExperimentalCoroutinesApi
@@ -41,14 +37,12 @@ class StoreThrowOnNoItems(
         whenever(fetcher.fetch(barCode))
                 .thenThrow(NoSuchElementException())
 
-       try {
-           simpleStore.get(barCode)
-           fail("exception not thrown when no items emitted from fetcher")
-
-       }
-       catch(e:NoSuchElementException){
-           assertThat(e).isInstanceOf(NoSuchElementException::class.java)
-       }
+        try {
+            simpleStore.get(barCode)
+            fail("exception not thrown when no items emitted from fetcher")
+        } catch (e: NoSuchElementException) {
+            assertThat(e).isInstanceOf(NoSuchElementException::class.java)
+        }
     }
 
     companion object {

--- a/store/src/test/java/com/nytimes/android/external/store3/StoreThrowOnNoItems.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/StoreThrowOnNoItems.kt
@@ -1,0 +1,64 @@
+package com.nytimes.android.external.store3
+
+import com.nhaarman.mockitokotlin2.*
+import com.nytimes.android.external.cache3.CacheBuilder
+import com.nytimes.android.external.store3.base.Fetcher
+import com.nytimes.android.external.store3.base.Persister
+import com.nytimes.android.external.store3.base.impl.BarCode
+import com.nytimes.android.external.store3.base.impl.StalePolicy
+import com.nytimes.android.external.store3.util.NoopPersister
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@ExperimentalCoroutinesApi
+@FlowPreview
+@RunWith(Parameterized::class)
+class StoreThrowOnNoItems(
+        private val storeType: TestStoreType
+) {
+    private val testScope = TestCoroutineScope()
+    private val counter = AtomicInteger(0)
+    private val fetcher: Fetcher<String, BarCode> = mock()
+    private var persister: Persister<String, BarCode> = mock()
+    private val barCode = BarCode("key", "value")
+
+    @Test
+    fun testShouldThrowOnFetcherEmitsNoSuckElementException() = testScope.runBlockingTest {
+        val simpleStore = TestStoreBuilder.from(
+                fetcher = fetcher
+        ).build(storeType)
+
+        whenever(fetcher.fetch(barCode))
+                .thenThrow(NoSuchElementException())
+
+       try {
+           simpleStore.get(barCode)
+           fail("exception not thrown when no items emitted from fetcher")
+
+       }
+       catch(e:NoSuchElementException){
+           assertThat(e).isInstanceOf(NoSuchElementException::class.java)
+       }
+    }
+
+    companion object {
+        private const val DISK = "disk"
+        private const val NETWORK = "fresh"
+        private const val MEMORY = "memory"
+        private const val ERROR = "error!!"
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun params() = TestStoreType.values()
+    }
+}

--- a/store/src/test/java/com/nytimes/android/external/store3/StreamOneKeyTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/StreamOneKeyTest.kt
@@ -7,7 +7,8 @@ import com.nytimes.android.external.store3.base.Persister
 import com.nytimes.android.external.store3.base.impl.BarCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -23,7 +24,6 @@ class StreamOneKeyTest(
 
     val fetcher: Fetcher<String, BarCode> = mock()
     val persister: Persister<String, BarCode> = mock()
-
     private val barCode = BarCode("key", "value")
     private val barCode2 = BarCode("key2", "value2")
 
@@ -31,9 +31,10 @@ class StreamOneKeyTest(
             fetcher = fetcher,
             persister = persister
     ).build(storeType)
+    private val testScope = TestCoroutineScope()
 
     @Before
-    fun setUp() = runBlocking<Unit> {
+    fun setUp() = runBlockingTest {
         whenever(fetcher.fetch(barCode))
                 .thenReturn(TEST_ITEM)
                 .thenReturn(TEST_ITEM2)
@@ -59,7 +60,7 @@ class StreamOneKeyTest(
 
     @Suppress("UsePropertyAccessSyntax") // for assert isTrue() isFalse()
     @Test
-    fun testStream() = runBlocking<Unit> {
+    fun testStream() = runBlockingTest {
         val streamSubscription = store.stream(barCode)
                 .openChannelSubscription()
         try {

--- a/store/src/test/java/com/nytimes/android/external/store3/StreamOneKeyTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/StreamOneKeyTest.kt
@@ -72,7 +72,7 @@ class StreamOneKeyTest(
             }
 
 
-            store.clearMemory()
+            store.clear(barCode)
 
             if (storeType == TestStoreType.Store) {
                 //fresh should notify subscribers in Store. In Pipeline, calling stream

--- a/store/src/test/java/com/nytimes/android/external/store3/pipeline/PipelineStoreTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/pipeline/PipelineStoreTest.kt
@@ -2,6 +2,7 @@ package com.nytimes.android.external.store3.pipeline
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -140,7 +141,7 @@ class PipelineStoreTest {
     }
 
     suspend fun PipelineStore<Int, String>.get(request : StoreRequest<Int>) =
-            this.stream(request).take(1).toList().first()
+            this.stream(request).first()
 
     suspend fun PipelineStore<Int, String>.get(key: Int) = get(
         StoreRequest.cached(


### PR DESCRIPTION
* Remove `clearMemory()`
* upgrade coroutines
* change `take(1).list().first()` to `.first()`
* write test to verify no items from fetcher will throw exception