### PR TITLE
Updated coroutines to 1.3.0 RC02 and fix Flow invariance

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -53,7 +53,7 @@ ext.versions = [
         supportTestRunner    : '0.4.1',
         espresso             : '2.2.1',
         compileTesting       : '0.8',
-        coroutines           : '1.2.2',
+        coroutines           : '1.3.0-RC2',
 ]
 
 ext.libraries = [


### PR DESCRIPTION
This PR fixes an invariance problem in side collect where it was
creating a scope and emitting from there.